### PR TITLE
Fix/minor doc typo fixes

### DIFF
--- a/continuous_eval/metrics/generation_LLM_based_metrics.py
+++ b/continuous_eval/metrics/generation_LLM_based_metrics.py
@@ -88,7 +88,7 @@ class LLMBasedAnswerCorrectness(LLMBasedMetric):
 
     def calculate(self, question, answer, ground_truths, **kwargs):
         """
-        Calculate the faithfulness score for the given datapoint.
+        Calculate the correctness score for the given datapoint.
         """
         gt_answers = "\n".join(ground_truths)
         if self.use_few_shot:
@@ -145,7 +145,7 @@ class LLMBasedAnswerRelevance(LLMBasedMetric):
 
     def calculate(self, question, answer, **kwargs):
         """
-        Calculate the faithfulness score for the given datapoint.
+        Calculate the answer relevance score for the given datapoint.
         """
         if self.use_few_shot:
             few_shot_prompt = """
@@ -191,8 +191,8 @@ Use the following guidelines for evaluation:
 
 class LLMBasedStyleConsistency(LLMBasedMetric):
     """
-    The LLM based answer relevance metric.
-    Measures whether the generated answer is relevant to the question.
+    The LLM based style consistency metric.
+    Measures whether the generated answer is consistent in style to the ground truth answer.
     """
 
     def __init__(self, model: Optional[LLMInterface] = None, use_few_shot: bool = True):
@@ -204,7 +204,7 @@ class LLMBasedStyleConsistency(LLMBasedMetric):
 
     def calculate(self, answer, ground_truths, **kwargs):
         """
-        Calculate the faithfulness score for the given datapoint.
+        Calculate the style consistency score for the given datapoint.
         """
         gt_answers = "\n".join(ground_truths)
         if self.use_few_shot:
@@ -224,7 +224,7 @@ The generated answer is more brief and doesn't have the formality and empathetic
             "system_prompt": (
                 """
 You are an expert evaluator system for a question answering system.
-You need to evaluate the style of the generated answer based on some reference answers.
+You only need to evaluate the style of the generated answer based on some reference answers, regardless of whether the answer is correct or not.
 Assess style aspects such as tone, verbosity, formality, complexity, use of terminology, etc.
 Output a score and the reasoning for your score in a new line.
 Use the following guidelines for evaluation:

--- a/continuous_eval/metrics/retrieval_LLM_based_metrics.py
+++ b/continuous_eval/metrics/retrieval_LLM_based_metrics.py
@@ -21,7 +21,7 @@ class LLMBasedContextPrecision(LLMBasedMetric):
 
     def calculate(self, question, retrieved_contexts, **kwargs):
         """
-        Calculate the context relevance score for the given datapoint.
+        Calculate the context precision score for the given datapoint.
         """
         scores = []
         for context in retrieved_contexts:
@@ -87,7 +87,7 @@ class LLMBasedContextCoverage(LLMBasedMetric):
 
     def calculate(self, question, retrieved_contexts, answer, **kwargs):
         """
-        Calculate the context relevance score for the given datapoint.
+        Calculate the context coverage score for the given datapoint.
         """
         context = "\n".join(retrieved_contexts)
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -27,12 +27,12 @@ import { Icon } from '@astrojs/starlight/components';
   <LinkCard
     title="🔍 Datasets"
     description="Perform evaluations on your datasets, or generate synthetic datasets from your vectorDB."
-    href="/evaluators/dataset/"
+    href="/dataset/dataset/"
   />
   <LinkCard
     title="💡 Examples"
     description="Discover code snippets and examples to help you understand and implement different evaluation pipelines."
-    href="/examples/single_metric/"
+    href="/examples/0_single_metric/"
   />
 </CardGrid>
 

--- a/docs/src/content/docs/metrics/ensembling/ensembling_classifier.md
+++ b/docs/src/content/docs/metrics/ensembling/ensembling_classifier.md
@@ -153,7 +153,7 @@ def judicator(idx):
     # and in this case, since we are computing the correctness of the sample,
     # it returns True if the example is correct and False otherwise
     datum = datasplit.test_full.X.iloc[idx].to_dict()
-    return llm_metric.calculate(**datum)["LLM_based_answer_correctness"] >= 3
+    return llm_metric.calculate(**datum)["LLM_based_answer_correctness"] >= 0.5
 ```
 
 To use the judicator we simply pass it to the `predict` method:

--- a/examples/ensemble_metric_with_judicator.py
+++ b/examples/ensemble_metric_with_judicator.py
@@ -45,7 +45,7 @@ def judicator(idx):
     # and in this case, since we are computing the correctness of the sample,
     # it returns True if the example is correct and False otherwise
     datum = datasplit.test_full.X.iloc[idx].to_dict()
-    return llm_metric.calculate(**datum)["LLM_based_answer_correctness"] >= 3
+    return llm_metric.calculate(**datum)["LLM_based_answer_correctness"] >= 0.5
 
 
 # Let's train a metric ensamble classifier


### PR DESCRIPTION
1. fixed links in docs
2. fixed typos in LLM metric docstrings
3. updated style consistency metric prompt slightly
4. fixed judicator threshold to match normalized score

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 48507ffff265c6565fc39edd10164e612551f7b2.  | 
|--------|--------|

### Summary:
This PR corrects various typos in docstrings and documentation, and updates the judicator threshold in the ensembling classifier.

**Key points**:
- Fixed docstring typos in `calculate` methods of `LLMBasedAnswerCorrectness`, `LLMBasedAnswerRelevance`, and `LLMBasedStyleConsistency` in `/continuous_eval/metrics/generation_LLM_based_metrics.py`.
- Fixed docstring typos in `calculate` methods of `LLMBasedContextPrecision` and `LLMBasedContextCoverage` in `/continuous_eval/metrics/retrieval_LLM_based_metrics.py`.
- Fixed broken links and updated prompt in `/docs/src/content/docs/index.mdx`.
- Updated judicator threshold in `/docs/src/content/docs/metrics/ensembling/ensembling_classifier.md` and `/examples/ensemble_metric_with_judicator.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
