### PR TITLE
fix context coverage metric input

### DIFF
--- a/continuous_eval/metrics/retrieval_LLM_based_metrics.py
+++ b/continuous_eval/metrics/retrieval_LLM_based_metrics.py
@@ -137,13 +137,13 @@ classification:
                         "LLM_based_context_statements": content,
                     }
                 )
-
-            scores.append(
-                {
-                    "LLM_based_context_coverage": coverage,
-                    "LLM_based_context_statements": content,
-                }
-            )
+            else:
+                scores.append(
+                    {
+                        "LLM_based_context_coverage": coverage,
+                        "LLM_based_context_statements": content,
+                    }
+                )
 
         return max(scores, key=lambda x: x["LLM_based_context_coverage"])
 

--- a/docs/src/content/docs/metrics/Retrieval/LLM-Based/llm_context_coverage.md
+++ b/docs/src/content/docs/metrics/Retrieval/LLM-Based/llm_context_coverage.md
@@ -16,6 +16,8 @@ $$
 }
 $$
 
+This metric requires the LLM evaluator to output correct and complex JSON. If the JSON cannot be parsed, the score returns -1.0.
+
 
 ### Example Usage
 
@@ -41,9 +43,9 @@ print(metric.calculate(**datum))
 ### Sample Output
 
 ```JSON
-{   
-    'LLM_based_context_coverage': 0.5,
-    'LLM_based_context_statements': 
+{
+    'LLM_based_context_coverage': 0.5, 
+    'LLM_based_context_statements':
     {
         "classification": [
             {
@@ -52,8 +54,8 @@ print(metric.calculate(**datum))
                 "Attributed": 1
             },
             {
-                "statement_2": "Lyon is the second largest city in France.",
-                "reason": "The context does not provide information about the ranking of Lyon in terms of size compared to other French cities.",
+                "statement_2": "Marseille is the second largest city in France.",
+                "reason": "This information is not provided in the context, which only mentions Paris and Lyon.",
                 "Attributed": 0
             }
         ]


### PR DESCRIPTION
Updated input from answer to ground_truth answers

<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit c4110e31bd4b271f90670508abe4828a8a81c8b2.  | 
|--------|--------|

### Summary:
This PR updates the `calculate` method in `LLMBasedContextCoverage` to iterate over `ground_truths` instead of `answer`, returning the maximum score among all ground truths, and updates the corresponding documentation.

**Key points**:
- Updated `calculate` method in `LLMBasedContextCoverage` class in `continuous_eval/metrics/retrieval_LLM_based_metrics.py`.
- Replaced `answer` input with `ground_truths` and iterated over it to calculate scores.
- Method now returns maximum score among all ground truths.
- In case of error during calculation, score is set to -1.0.
- Updated documentation in `docs/src/content/docs/metrics/Retrieval/LLM-Based/llm_context_coverage.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
<!--
ELLIPSIS_HIDDEN
-->
