### PR TITLE
Change default matching strategy to RougeChunkMatch, issue #25

### DIFF
--- a/continuous_eval/metrics/retrieval_precision_recall_f1.py
+++ b/continuous_eval/metrics/retrieval_precision_recall_f1.py
@@ -1,11 +1,11 @@
 from nltk.tokenize import sent_tokenize
 
 from continuous_eval.metrics.base import Metric
-from continuous_eval.metrics.retrieval_matching_strategy import ExactChunkMatch, MatchingStrategy, MatchingStrategyType
+from continuous_eval.metrics.retrieval_matching_strategy import RougeChunkMatch, MatchingStrategy, MatchingStrategyType
 
 
 class PrecisionRecallF1(Metric):
-    def __init__(self, matching_strategy: MatchingStrategy = ExactChunkMatch()):
+    def __init__(self, matching_strategy: MatchingStrategy = RougeChunkMatch()):
         super().__init__()
         assert isinstance(
             matching_strategy, MatchingStrategy

--- a/continuous_eval/metrics/retrieval_ranked_metrics.py
+++ b/continuous_eval/metrics/retrieval_ranked_metrics.py
@@ -1,11 +1,11 @@
 from math import log
 
 from continuous_eval.metrics.base import Metric
-from continuous_eval.metrics.retrieval_matching_strategy import ExactChunkMatch, MatchingStrategy, MatchingStrategyType
+from continuous_eval.metrics.retrieval_matching_strategy import RougeChunkMatch, MatchingStrategy, MatchingStrategyType
 
 
 class RankedRetrievalMetrics(Metric):
-    def __init__(self, matching_strategy: MatchingStrategy = ExactChunkMatch()) -> None:
+    def __init__(self, matching_strategy: MatchingStrategy = RougeChunkMatch()) -> None:
         super().__init__()
         self.matching_strategy = matching_strategy
         assert isinstance(


### PR DESCRIPTION
issue #25 
<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit ec9101f77a614bf75a79df683f2c4f5c225fb3ce.  | 
|--------|--------|

### Summary:
This PR changes the default matching strategy in `PrecisionRecallF1` and `RankedRetrievalMetrics` from `ExactChunkMatch` to `RougeChunkMatch`.

**Key points**:
- Changed default matching strategy in `PrecisionRecallF1` and `RankedRetrievalMetrics` classes.
- The matching strategy was changed from `ExactChunkMatch` to `RougeChunkMatch`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
