### PR TITLE
fixed double counting issue for precision / average precision

### DIFF
--- a/continuous_eval/metrics/retrieval/precision_recall_f1.py
+++ b/continuous_eval/metrics/retrieval/precision_recall_f1.py
@@ -30,12 +30,15 @@ class PrecisionRecallF1(Metric):
 
         relevant_ret_components = 0
         hit_gt_components = set()
+        gt_components = set(gt_components)  # remove duplicates in ground truth context if any
         for ret_component in ret_components:
+            ret_component_matched = False
             for gt_component in gt_components:
                 if self.matching_strategy.is_relevant(ret_component, gt_component):
-                    relevant_ret_components += 1
+                    ret_component_matched = True
                     hit_gt_components.add(gt_component)
                     continue
+            relevant_ret_components += int(ret_component_matched)
         precision = relevant_ret_components / len(ret_components) if ret_components else 0.0
         recall = len(hit_gt_components) / len(gt_components) if gt_components else 0.0
 

--- a/continuous_eval/metrics/retrieval/ranked.py
+++ b/continuous_eval/metrics/retrieval/ranked.py
@@ -34,7 +34,7 @@ class RankedRetrievalMetrics(Metric):
                 if self.matching_strategy.is_relevant(chunk, ground_truth_chunk):
                     relevant_chunks += 1
                     average_precision += relevant_chunks / (i + 1)
-                    continue
+                    break
 
         return average_precision / relevant_chunks if relevant_chunks else 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ google-generativeai = {version = "^0.3.1", optional = true}
 mapie = "^0.7.0"
 imbalanced-learn = "^0.11.0"
 pandas = "^2.1.4"
-protobuf = "^4.25.1"
+protobuf = "^4.23.4"
 tqdm = "^4.66.1"
 requests = "^2.31.0"
 pinecone-client = {version = "^2.2.4", optional = true}


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit acded6d96a3e81b6c488e03ac708f3821ace8151.  | 
|--------|--------|

### Summary:
This PR fixes a double counting issue in precision and average precision calculations and downgrades the `protobuf` version.

**Key points**:
- Modified `precision_recall_f1.py` to prevent double counting of retrieved components.
- Updated `ranked.py` to break the loop after finding the first relevant match.
- Downgraded `protobuf` version in `pyproject.toml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
