### PR TITLE
Fix required keyword for code string to ground_truth_answers

### DIFF
--- a/docs/src/content/docs/metrics/Code/Deterministic/python_ast_similarity.md
+++ b/docs/src/content/docs/metrics/Code/Deterministic/python_ast_similarity.md
@@ -18,7 +18,7 @@ The metric depends on syntactically correct Python scripts to produce the Abstra
 
 ### Example Usage
 
-Required data items: `answer`, `ground_truths`
+Required data items: `answer`, `ground_truth_answers`
 
 ```python
 from continuous_eval.metrics.code.python import PythonASTSimilarity

--- a/docs/src/content/docs/metrics/Code/Deterministic/string_match.md
+++ b/docs/src/content/docs/metrics/Code/Deterministic/string_match.md
@@ -15,14 +15,14 @@ It outputs both the binary exact match score and the fuzzy match score in the ra
 
 ### Example Usage
 
-Required data items: `answer`, `ground_truths`
+Required data items: `answer`, `ground_truth_answers`
 
 ```python
 from continuous_eval.metrics.code.python import CodeStringMatch
 
 datum = {
     "answer": "def function(x, y):\n  return x + y",
-    "ground_truths": [
+    "ground_truth_answers": [
         "def foo(x, y):\n  return x * y",
         "def foo(x, y):\n  return x + y",
     ],


### PR DESCRIPTION
thanks for this awesome library.

small docs fixes for code string match metrics: setting keyword to ground_truth_answers

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit a21ae5a47348114f932b1562c35b12a906857812.  | 
|--------|--------|

### Summary:
This PR updates the keyword from `ground_truths` to `ground_truth_answers` in the documentation of two metrics.

**Key points**:
- Updated keyword from `ground_truths` to `ground_truth_answers` in documentation.
- Files affected: `/docs/src/content/docs/metrics/Code/Deterministic/python_ast_similarity.md` and `/docs/src/content/docs/metrics/Code/Deterministic/string_match.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
