### PR TITLE
Fix contexts attribute name in examples documentation

### DIFF
--- a/docs/src/content/docs/examples/Basics/1_evaluation_on_dataset.md
+++ b/docs/src/content/docs/examples/Basics/1_evaluation_on_dataset.md
@@ -20,12 +20,12 @@ pipeline = SingleModulePipeline(
     dataset=dataset,
     eval=[
         PrecisionRecallF1().use(
-            retrieved_context=dataset.retrieved_context,
-            ground_truth_context=dataset.ground_truth_context,
+            retrieved_context=dataset.retrieved_contexts,
+            ground_truth_context=dataset.ground_truth_contexts,
         ),
         RankedRetrievalMetrics().use(
-            retrieved_context=dataset.retrieved_context,
-            ground_truth_context=dataset.ground_truth_context,
+            retrieved_context=dataset.retrieved_contexts,
+            ground_truth_context=dataset.ground_truth_contexts,
         ),
     ],
 )


### PR DESCRIPTION
Fix names of `retrieved_contexts` and `ground_truth_contexts` attributes from `Dataset` in "examples" documentation.

This makes it ISO with the quickstart.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 306ffe3623273a3c6500a80fce2ede9e354c9dcb  | 
|--------|

### Summary:
Updated attribute names in the example documentation to match the `Dataset` class definitions.

**Key points**:
- Corrected attribute names in `1_evaluation_on_dataset.md` from `retrieved_context` and `ground_truth_context` to `retrieved_contexts` and `ground_truth_contexts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
