### PR TITLE
Integrating DSPy

### DIFF
--- a/continuous_eval/metrics/integrations/dspy.py
+++ b/continuous_eval/metrics/integrations/dspy.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict
+
+import dspy
+
+from continuous_eval.metrics.base import Metric
+
+
+class DspyMetricAdapter(Metric):
+    def __init__(self, dspy_module: dspy.Module):
+        super().__init__()
+        self.dspy_module = dspy_module
+
+    def __call__(self, **kwargs) -> Dict[str, Any]:
+
+        dspy_outputs = self.dspy_module.forward(**kwargs)
+
+        metric_outputs = self._convert_outputs(dspy_outputs)
+
+        return metric_outputs
+
+    def _convert_outputs(self, outputs: Any) -> Dict[str, Any]:
+
+        return {"score": outputs}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ cohere = {version = "^4.54", optional = true}
 boto3 = {version = "^1.34.70", optional = true}
 google-generativeai = {version = "^0.3.1", optional = true}
 anthropic = {version = "^0.7.7", optional = true}
+dspy-ai = {version = ">=0.1.9", optional = true}
 
 [tool.poetry.group.semantic]
 optional = true

--- a/tests/integrations_test.py
+++ b/tests/integrations_test.py
@@ -1,0 +1,59 @@
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+import dspy
+from dspy.datasets import HotpotQA
+
+from continuous_eval.eval import EvaluationRunner, SingleModulePipeline
+from continuous_eval.metrics.integrations.dspy import DspyMetricAdapter
+
+# Set up the LM
+turbo = dspy.OpenAI(model='gpt-3.5-turbo-instruct', max_tokens=250)
+dspy.settings.configure(lm=turbo)
+
+
+@dataclass
+class HotpotQATone(HotpotQA):
+    tone: str = None
+
+    def __getitem__(self, index):
+        item = super().__getitem__(index)
+        item.tone = random.choice(["positive", "negative"])  # bad, but for testing purposes
+        return item
+
+
+hotpotqa_dataset = HotpotQATone(HotpotQA())
+
+
+class Tone(dspy.Module):
+    def __init__(self):
+        super().__init__()
+
+        self._signature = dspy.ChainOfThought(
+            prompt_template="""Analyze the tone of the following answer and return if its positive or negative:
+
+Answer:
+{answer}
+
+Description:"""
+        )
+
+    def forward(self, answer):
+        return self._signature(answer=answer)
+
+
+tone_metric = DspyMetricAdapter(Tone())
+
+pipeline = SingleModulePipeline(
+    dataset=hotpotqa_dataset,
+    eval=[
+        tone_metric.use(
+            answer=lambda x: x.answer,
+            ground_truth=lambda x: x.tone,
+        ),
+    ],
+)
+
+runner = EvaluationRunner(pipeline)
+eval_results = runner.evaluate()

--- a/tests/integrations_test.py
+++ b/tests/integrations_test.py
@@ -1,14 +1,17 @@
 import random
 from dataclasses import dataclass
-from pathlib import Path
 
 import dspy
+
+# Set up the LM
+from dotenv import load_dotenv
 from dspy.datasets import HotpotQA
 
 from continuous_eval.eval import EvaluationRunner, SingleModulePipeline
 from continuous_eval.metrics.integrations.dspy import DspyMetricAdapter
 
-# Set up the LM
+load_dotenv()
+
 turbo = dspy.OpenAI(model='gpt-3.5-turbo-instruct', max_tokens=250)
 dspy.settings.configure(lm=turbo)
 


### PR DESCRIPTION
I made this a draft pull request, because [the ticket](https://github.com/relari-ai/continuous-eval/issues/64) is nowhere near done. 

Currently when I run the ``integrations_test.py`` to get a feel for what the ``_convert_outputs()`` function in ``dspy.py`` _should be_ (its currently just 👇)
```python

    def _convert_outputs(self, outputs: Any) -> Dict[str, Any]:

        return {"score": outputs}
```

I get a  ``ModuleNotFoundError: No module named 'openai.error'``

This can happen in[ DSPy sometimes](https://github.com/stanfordnlp/dspy/issues/220), but I wouldn't expect it to since my openai version is appropriate. Running ``poetry show openai`` gets me

```bash
 name         : openai                                         
 version      : 1.30.1                                         
 description  : The official Python library for the openai API 

dependencies
 - anyio >=3.5.0,<5
 - distro >=1.7.0,<2
 - httpx >=0.23.0,<1
 - pydantic >=1.9.0,<3
 - sniffio *
 - tqdm >4
 - typing-extensions >=4.7,<5

required by
 - dspy-ai *
 - langchain-openai >=1.24.0,<2.0.0
``` 

1) **Have you all dealt with this?**
2) **Does running ``poetry run pytest tests/integrations_test.py`` garner the same error?**

I'm on DSPy version 2.0.4.

If I remove ``langchain-openai`` since that requires ``openai`` to be `` >=1.24.0,<2.0.0`` and go to the earliest version of ``openai`` allowed by ``continuous-eval`` (namely version ``1.3.7``) that doesn't fix the problem. 

@pantonante 