### PR TITLE
add max_tokens field for llm interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ ANTHROPIC_API_KEY="sk-ant-xxxx"
 # For Gemini
 GEMINI_API_KEY="xxxx"
 
+# For Cohere
+COHERE_API_KEY="xxxx"
+
 # For Azure OpenAI
 AZURE_OPENAI_API_KEY="sk-xxxx"
 AZURE_OPENAI_API_VERSION="2023-03-15-preview"


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a9e8583a6516e711a4347d9cf1d3ed4e2baf429d  | 
|--------|

### Summary:
This PR introduces a `max_tokens` parameter to the LLM interface methods, allowing control over the number of tokens generated, and adds Cohere API key support in the environment configuration.

**Key points**:
- Added `max_tokens` parameter to `LLMInterface.run` and `LLMFactory.run` with a default of 1024.
- Updated `_llm_response` in `LLMFactory` to pass `max_tokens` to LLM client calls.
- Added `COHERE_API_KEY` to `.env.example`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
