### PR TITLE
fix progress bar always 1 short | updated generator in examples to 4o

### DIFF
--- a/continuous_eval/generators/simple.py
+++ b/continuous_eval/generators/simple.py
@@ -273,6 +273,7 @@ class SimpleDatasetGenerator:
                 num_single_hop_tries += 1
                 continue
 
+        pbar.update(len(multi_hop_questions) + len(single_hop_questions) - pbar.n)
         pbar.close()
         dataset = single_hop_questions + multi_hop_questions
         for idx, d in enumerate(dataset):

--- a/docs/src/content/docs/examples/Advanced/dataset_generation.md
+++ b/docs/src/content/docs/examples/Advanced/dataset_generation.md
@@ -22,7 +22,7 @@ load_dotenv()
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    generator_llm = "gpt-4-0125-preview"
+    generator_llm = "gpt-4o"
     num_questions = 10
     multi_hop_precentage = 0.2
     max_try_ratio = 3

--- a/examples/simple_dataset_generation.py
+++ b/examples/simple_dataset_generation.py
@@ -16,10 +16,10 @@ load_dotenv()
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    generator_llm = "gpt-4-0125-preview"
-    num_questions = 2
-    multi_hop_precentage = 0.0
-    max_try_ratio = 5
+    generator_llm = "gpt-4o"
+    num_questions = 10
+    multi_hop_precentage = 0.2
+    max_try_ratio = 3
 
     print(f"Generating a {num_questions}-questions dataset with {generator_llm}...")
     db = example_data_downloader("graham_essays/small/chromadb", Path("temp"), force_download=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "continuous-eval"
-version = "0.3.9"
+version = "0.3.10"
 description = "Open-Source Evaluation for GenAI Application Pipelines."
 authors = ["Yi Zhang <yi@relari.ai>", "Pasquale Antonante <pasquale@relari.ai>"]
 readme = "README.md"


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 43542cc99fb0e14c83c43b327b263afd6549d460  | 
|--------|

### Summary:
This PR fixes the progress bar logic in the dataset generator and updates the generator model and parameters in example scripts.

**Key points**:
- Updated progress bar logic in `continuous_eval/generators/simple.py` to accurately reflect question count.
- Changed generator model from `gpt-4-0125-preview` to `gpt-4o` in example scripts.
- Adjusted parameters for question generation in example scripts.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
