### PR TITLE
Fix key name of retrieved_contexts in the dataset evaluation sample

### DIFF
--- a/examples/evaluation_on_dataset.py
+++ b/examples/evaluation_on_dataset.py
@@ -14,11 +14,11 @@ pipeline = SingleModulePipeline(
     dataset=dataset,
     eval=[
         PrecisionRecallF1().use(
-            retrieved_context=dataset.retrieved_context,  # type: ignore
+            retrieved_context=dataset.retrieved_contexts,  # type: ignore
             ground_truth_context=dataset.ground_truth_contexts,  # type: ignore
         ),
         RankedRetrievalMetrics().use(
-            retrieved_context=dataset.retrieved_context,  # type: ignore
+            retrieved_context=dataset.retrieved_contexts,  # type: ignore
             ground_truth_context=dataset.ground_truth_contexts,  # type: ignore
         ),
     ],


### PR DESCRIPTION
I hope I'm not misunderstanding something, but the relevant key in https://ceevaldata.blob.core.windows.net/examples/retrieval.jsonl is `retrieved_contexts`
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3f11459a9a1103eb857a4ee6a450b33a45fc0cb8  | 
|--------|--------|

### Summary:
This PR fixes the key name for retrieved contexts in the dataset evaluation sample to align with the dataset's JSON structure.

**Key points**:
- Corrects key name from `retrieved_context` to `retrieved_contexts` in `examples/evaluation_on_dataset.py`
- Affects `PrecisionRecallF1` and `RankedRetrievalMetrics` classes


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->