### PR TITLE
Fix issue #71

### DIFF
--- a/continuous_eval/metrics/generation/text/llm_based.py
+++ b/continuous_eval/metrics/generation/text/llm_based.py
@@ -73,7 +73,7 @@ The statement is supported by the context, which states that photosynthesis conv
                 score_txt, reasoning = response.split("\n", 1)
                 score = float("yes" in score_txt.lower())
             except ValueError:
-                score = float("yes" in score_txt.lower())
+                score = float("yes" in response.lower())
                 reasoning = response
 
         return {


### PR DESCRIPTION
Fixed issue #71 where responses that cannot be split fails

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6809468caed68a60c5eb6042c76e42f047b186c1  | 
|--------|--------|

### Summary:
Fixes a response handling error in `LLMBasedFaithfulness` by updating the exception handling to process the entire response if it cannot be split.

**Key points**:
- Fixed `ValueError` in `LLMBasedFaithfulness` class when response splitting fails
- Updated error handling to check for 'yes' in the entire response and use it as reasoning if splitting fails
- Modified in `continuous_eval/metrics/generation/text/llm_based.py`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->