### PR TITLE
Fix issue #69

### DIFF
--- a/continuous_eval/metrics/generation/text/llm_based.py
+++ b/continuous_eval/metrics/generation/text/llm_based.py
@@ -36,7 +36,7 @@ class LLMBasedFaithfulness(LLMBasedMetric):
         if self.classify_by_statement:
             # Context coverage uses the same prompt as faithfulness because it calculates how what proportion statements in the answer can be attributed to the context.
             # The difference is that faithfulness uses the generated answer, while context coverage uses ground truth answer (to evaluate context).
-            context_coverage = LLMBasedContextCoverage(use_few_shot=self.use_few_shot)
+            context_coverage = LLMBasedContextCoverage(model=self._llm, use_few_shot=self.use_few_shot)
             results = context_coverage(question, retrieved_context, answer)
             score = results["LLM_based_context_coverage"]
             reasoning = results["LLM_based_context_statements"]


### PR DESCRIPTION
Fix issue #69 where LLMs other than OpenAI APIs are not being called
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 52de4daad5b173c3463a2111c115eb212bd40a8a  | 
|--------|--------|

### Summary:
Fixes model passing in `LLMBasedFaithfulness` to ensure `LLMBasedContextCoverage` correctly utilizes the specified LLM model.

**Key points**:
- Updated `LLMBasedFaithfulness` class in `continuous_eval/metrics/generation/text/llm_based.py`.
- Fixed model passing to `LLMBasedContextCoverage` in `__call__` method.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->