### PR TITLE
⚡️ Speed up method `Integer._numeric_matcher` by 269% [codeflash]

### DIFF
--- a/continuous_eval/metrics/base/response_type.py
+++ b/continuous_eval/metrics/base/response_type.py
@@ -135,11 +135,10 @@ class Integer(ScoringFunction, ResponseFormatBaseType):
         return max(self._ge, min(self._le, num))
 
     def _numeric_matcher(self, input_val) -> Optional[float]:
-        pattern = r"\d+(?:\.\d+)?"  # Match any number (integer or float)
-        matches = re.findall(pattern, input_val)
-        if not matches:
+        match = re.search(r"\d+(?:\.\d+)?", input_val)
+        if not match:
             return None
-        return max(self._ge, min(self._le, float(matches[0])))
+        return max(self._ge, min(self._le, float(match.group())))
 
     @property
     def ge(self):


### PR DESCRIPTION
### 📄 269% (2.69x) speedup for ***`Integer._numeric_matcher` in `continuous_eval/metrics/base/response_type.py`***

⏱️ Runtime :   **`457 microseconds`**  **→** **`124 microseconds`** (best of `673` runs)
<details>
<summary> 📝 Explanation and details</summary>

Here is your optimized Python program.



Modifications.
1. Replaced `re.findall()` with `re.search()` and `match.group()`. `re.search()` will stop after the first match instead of finding all matches, making it more efficient for this use case.
2. Directly using `match.group()` to get the first and only match which reduces additional operations.

</details>

✅ **Correctness verification report:**


| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **47 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
import re
from typing import Optional

# imports
import pytest  # used for our unit tests
from continuous_eval.metrics.base.response_type import Integer


class ScoringFunction:
    pass

class ResponseFormatBaseType:
    pass
from continuous_eval.metrics.base.response_type import Integer

# unit tests

# Basic Functionality
def test_single_integer_input():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("42")
    codeflash_output = obj._numeric_matcher("5")
    codeflash_output = obj._numeric_matcher("60")

def test_single_floating_point_input():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("42.5")
    codeflash_output = obj._numeric_matcher("5.5")
    codeflash_output = obj._numeric_matcher("60.5")

# No Numeric Input
def test_empty_string():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("")

def test_no_numbers():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("abc")
    codeflash_output = obj._numeric_matcher("hello world")

# Multiple Numeric Values in Input
def test_multiple_integers():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("42 and 17")
    codeflash_output = obj._numeric_matcher("5 and 60")

def test_multiple_floating_point_numbers():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("42.5 and 17.2")
    codeflash_output = obj._numeric_matcher("5.5 and 60.5")

# Mixed Content
def test_alphanumeric_strings():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("abc123def")
    codeflash_output = obj._numeric_matcher("foo 42 bar")

def test_special_characters():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("@42!")
    codeflash_output = obj._numeric_matcher("#5$")

# Edge Cases
def test_bounds_as_input():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("10")
    codeflash_output = obj._numeric_matcher("50")

def test_negative_numbers():
    obj = Integer(-50, -10)
    codeflash_output = obj._numeric_matcher("-42")
    codeflash_output = obj._numeric_matcher("-60")

def test_decimal_edge_cases():
    obj = Integer(10, 50)
    codeflash_output = obj._numeric_matcher("10.0")
    codeflash_output = obj._numeric_matcher("50.0")

# Large Scale Test Cases
def test_large_input_string():
    obj = Integer(10, 500)
    large_input = " ".join(str(i) for i in range(1000))
    codeflash_output = obj._numeric_matcher(large_input)

def test_performance_with_large_numbers():
    obj = Integer(1000, 1000000)
    large_numbers = " ".join(str(i * 1000) for i in range(1000))
    codeflash_output = obj._numeric_matcher(large_numbers)

# Non-String Input (Type Checking)
def test_non_string_input():
    obj = Integer(10, 50)
    with pytest.raises(TypeError):
        obj._numeric_matcher(12345)
    with pytest.raises(TypeError):
        obj._numeric_matcher([42, 17])

# Run the tests
if __name__ == "__main__":
    pytest.main()
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

import re
from typing import Optional

# imports
import pytest  # used for our unit tests
from continuous_eval.metrics.base.response_type import Integer


class ScoringFunction:
    pass

class ResponseFormatBaseType:
    pass
from continuous_eval.metrics.base.response_type import Integer

# unit tests

# Basic Functionality
def test_single_integer_within_bounds():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("42")

def test_single_float_within_bounds():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("42.5")

# Edge Cases for Bounds
def test_input_equal_to_lower_bound():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("10")

def test_input_equal_to_upper_bound():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("50")

def test_input_below_lower_bound():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("5")

def test_input_above_upper_bound():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("55")

# No Numeric Value in Input
def test_empty_string():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("")

def test_non_numeric_string():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("abc")

# Multiple Numeric Values in Input
def test_multiple_integers():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("10 20 30")

def test_multiple_floats():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("10.5 20.5 30.5")

def test_mixed_integers_and_floats():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("10 20.5 30")

# Complex Strings with Numeric Values
def test_numeric_value_with_leading_and_trailing_characters():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("abc42xyz")

def test_numeric_value_with_special_characters():
    integer = Integer(10, 50)
    codeflash_output = integer._numeric_matcher("@42#")

# Negative and Zero Values
def test_negative_integer():
    integer = Integer(-10, 10)
    codeflash_output = integer._numeric_matcher("-5")

def test_negative_float():
    integer = Integer(-10, 10)
    codeflash_output = integer._numeric_matcher("-5.5")

def test_zero_value():
    integer = Integer(-10, 10)
    codeflash_output = integer._numeric_matcher("0")

# Large Numeric Values
def test_large_integer():
    integer = Integer(0, 1000000)
    codeflash_output = integer._numeric_matcher("1000000")

def test_large_float():
    integer = Integer(0, 1000000)
    codeflash_output = integer._numeric_matcher("999999.999")

# Performance and Scalability
def test_large_input_string():
    integer = Integer(0, 10000)
    large_input = " ".join(str(i) for i in range(1000))
    codeflash_output = integer._numeric_matcher(large_input)

# Invalid Boundaries
def test_invalid_boundaries():
    with pytest.raises(AssertionError):
        Integer(50, 10)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>



:loudspeaker: Feedback on this optimization? [![Discord](https://img.shields.io/badge/Discord-Join%20Our%20Community-7289DA)](https://codeflash.ai/discord)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes `Integer._numeric_matcher` in `response_type.py` for a 269% speedup by using `re.search()` and `match.group()` instead of `re.findall()`.
> 
>   - **Performance Optimization**:
>     - Optimizes `Integer._numeric_matcher` in `response_type.py` by replacing `re.findall()` with `re.search()` and using `match.group()` for efficiency.
>     - Achieves a 269% speedup, reducing runtime from 457 microseconds to 124 microseconds.
>   - **Testing**:
>     - 47 generated regression tests passed, ensuring correctness.
>     - 100% test coverage confirmed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=relari-ai%2Fcontinuous-eval&utm_source=github&utm_medium=referral)<sup> for 867236f6a8a922d0891c18aa380cac5555f8f2e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->