### PR TITLE
⚡️ Speed up method `CodeStringMatch.compute` by 184% [codeflash]

### DIFF
--- a/continuous_eval/metrics/code/python/code_deterministic_metrics.py
+++ b/continuous_eval/metrics/code/python/code_deterministic_metrics.py
@@ -18,13 +18,21 @@ class CodeStringMatch(Metric):
     def compute(self, answer: str, ground_truth_answers: List[str], **kwargs):
         max_exact_match = 0
         max_similarity_score = 0
+
         for gt in ground_truth_answers:
-            exact_match = float(answer == gt)
-            similarity_score = fuzz.ratio(answer, gt) / 100
-            if exact_match > max_exact_match:
-                max_exact_match = exact_match
-            if similarity_score > max_similarity_score:
-                max_similarity_score = similarity_score
+            if answer == gt:
+                max_exact_match = (
+                    1.0  # Exact match found, no need to check further
+                )
+                max_similarity_score = (
+                    1.0  # Similarity score is also 1 for exact match
+                )
+                break
+            else:
+                similarity_score = fuzz.ratio(answer, gt) / 100
+                if similarity_score > max_similarity_score:
+                    max_similarity_score = similarity_score
+
         return {
             "Exact_Match_Score": max_exact_match,
             "Fuzzy_Match_Score": max_similarity_score,


### PR DESCRIPTION
### 📄 184% (1.84x) speedup for ***`CodeStringMatch.compute` in `continuous_eval/metrics/code/python/code_deterministic_metrics.py`***

⏱️ Runtime :   **`11.0 milliseconds`**  **→** **`3.86 milliseconds`** (best of `474` runs)
<details>
<summary> 📝 Explanation and details</summary>

To improve the performance of the `compute` method, we can perform the exact match check first since it is computationally cheaper compared to computing the similarity score. We can also streamline the code a bit for readability. Here's an optimized version of the program.



Changes made.
1. Perform the exact match check first since it's computationally inexpensive. If an exact match is found, exit early (`break`) as there is no need for further checks.
2. Only compute the similarity score if no exact match is found.
3. Removed redundant float conversion for `exact_match`.

This should provide a performance improvement by reducing the number of expensive `fuzz.ratio` calls when an exact match is found earlier in the list of `ground_truth_answers`.

</details>

✅ **Correctness verification report:**


| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **48 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
from typing import List

# imports
import pytest  # used for our unit tests
# function to test
from continuous_eval.metrics.base import Metric
from continuous_eval.metrics.code.python.code_deterministic_metrics import \
    CodeStringMatch
from thefuzz import fuzz

# unit tests

# Basic Functionality
def test_exact_match_only():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("hello", ["hello"])
    codeflash_output = csm.compute("world", ["world", "hello"])

def test_fuzzy_match_only():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("helo", ["hello"])
    codeflash_output = csm.compute("worl", ["world", "hello"])

def test_no_match():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("foo", ["bar", "baz"])
    codeflash_output = csm.compute("apple", ["orange", "banana"])

# Edge Cases
def test_empty_ground_truth_answers():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("test", [])

def test_empty_answer_string():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("", ["test", "example"])

def test_both_empty():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("", [])

def test_case_sensitivity():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("Hello", ["hello"])
    codeflash_output = csm.compute("WORLD", ["world"])

# Special Characters and Spaces
def test_whitespace_handling():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("hello world", ["hello world", "helloworld"])
    codeflash_output = csm.compute("  hello  ", ["hello"])

def test_special_characters():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("hello!", ["hello"])
    codeflash_output = csm.compute("foo@bar", ["foo@bar", "foobar"])

# Large Scale Test Cases
def test_large_number_of_ground_truth_answers():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("test", ["test" * i for i in range(1000)])

def test_long_strings():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("a" * 1000, ["a" * 1000, "b" * 1000])
    codeflash_output = csm.compute("a" * 500 + "b" * 500, ["a" * 1000, "b" * 1000])

# Mixed Cases
def test_exact_and_fuzzy_matches():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("test", ["test", "tst", "teest"])
    codeflash_output = csm.compute("example", ["example", "exmple", "exampel"])

def test_multiple_best_matches():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("test", ["test", "test"])
    codeflash_output = csm.compute("example", ["example", "example"])

# Performance and Scalability
def test_stress_test_with_large_inputs():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("performance", ["performance" * i for i in range(1000)])
    codeflash_output = csm.compute("scalability", ["scalability" * i for i in range(1000)])

# Boundary Conditions
def test_minimum_length_strings():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("a", ["a", "b"])
    codeflash_output = csm.compute("b", ["a", "b"])

def test_maximum_length_strings():
    csm = CodeStringMatch()
    codeflash_output = csm.compute("a" * 10000, ["a" * 10000, "b" * 10000])
    codeflash_output = csm.compute("b" * 10000, ["a" * 10000, "b" * 10000])
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

from typing import List

# imports
import pytest  # used for our unit tests
# function to test
from continuous_eval.metrics.base import Metric
from continuous_eval.metrics.code.python.code_deterministic_metrics import \
    CodeStringMatch
from thefuzz import fuzz


# unit tests
def test_single_exact_match():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("hello", ["hello"])

def test_no_exact_match_single_fuzzy_match():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("hello", ["helo"])

def test_multiple_ground_truths_one_exact_match():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("hello", ["hi", "hello", "hey"])

def test_empty_answer_string():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("", ["hello", "world"])

def test_empty_ground_truth_list():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("hello", [])

def test_both_answer_and_ground_truths_empty():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("", [""])

def test_case_sensitivity():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("Hello", ["hello"])

def test_special_characters():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("hello!", ["hello", "hello!"])

def test_leading_and_trailing_whitespace():
    metric = CodeStringMatch()
    codeflash_output = metric.compute(" hello ", ["hello", " hello "])

def test_whitespace_variations():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("hello world", ["hello  world", "hello world"])

def test_long_strings():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("a" * 1000, ["a" * 1000, "b" * 1000])

def test_large_number_of_ground_truths():
    metric = CodeStringMatch()
    ground_truths = ["test" + str(i) for i in range(1000)]
    codeflash_output = metric.compute("test", ground_truths)

def test_high_similarity_but_not_exact():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("kitten", ["sitting", "kitten"])

def test_low_similarity():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("apple", ["banana", "grape"])

def test_mixed_case():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("HelloWorld", ["helloworld", "HelloWorld"])

def test_special_characters_mixed_with_text():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("hello@world.com", ["hello@world.com", "hello@world.co"])

def test_very_large_ground_truth_list():
    metric = CodeStringMatch()
    ground_truths = ["performance" + str(i) for i in range(1000)]
    codeflash_output = metric.compute("performance", ground_truths)

def test_very_long_answer_and_ground_truths():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("a" * 10000, ["a" * 10000, "b" * 10000])

def test_common_typos():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("recieve", ["receive", "recieve"])

def test_common_phrases():
    metric = CodeStringMatch()
    codeflash_output = metric.compute("to be or not to be", ["to be or not to be", "to be or not to bee"])
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>



:loudspeaker: Feedback on this optimization? [![Discord](https://img.shields.io/badge/Discord-Join%20Our%20Community-7289DA)](https://codeflash.ai/discord)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `CodeStringMatch.compute` for performance by checking exact matches first and reducing unnecessary similarity calculations.
> 
>   - **Performance Optimization**:
>     - Reorder operations in `CodeStringMatch.compute` to check for exact matches first, exiting early if found.
>     - Only compute similarity score if no exact match is found.
>     - Remove redundant float conversion for `exact_match`.
>   - **Testing**:
>     - Generated 48 regression tests to verify correctness of changes.
>     - Test coverage is 100%.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=relari-ai%2Fcontinuous-eval&utm_source=github&utm_medium=referral)<sup> for 905047910fe4ebc4a5767bd8e2212c162d1de651. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->